### PR TITLE
Add header to product detail page

### DIFF
--- a/app/product-detail/ProductDetail.tsx
+++ b/app/product-detail/ProductDetail.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
+import Header from '../components/Header';
 
 interface ProductDetailData {
   id: number;
@@ -127,220 +128,232 @@ export default function ProductDetail() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-gray-500">
-        正在加载产品详情...
+      <div className="min-h-screen bg-white flex flex-col">
+        <Header />
+        <main className="flex-1 pt-20 sm:pt-24 flex items-center justify-center text-gray-500">
+          正在加载产品详情...
+        </main>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold text-gray-900 mb-4">产品详情加载失败</h1>
-          <p className="text-gray-600 mb-6">{error}</p>
-          <Link href="/" className="text-blue-600 hover:text-blue-700">
-            Return to Home
-          </Link>
-        </div>
+      <div className="min-h-screen bg-white flex flex-col">
+        <Header />
+        <main className="flex-1 pt-20 sm:pt-24 flex items-center justify-center">
+          <div className="text-center">
+            <h1 className="text-2xl font-semibold text-gray-900 mb-4">产品详情加载失败</h1>
+            <p className="text-gray-600 mb-6">{error}</p>
+            <Link href="/" className="text-blue-600 hover:text-blue-700">
+              Return to Home
+            </Link>
+          </div>
+        </main>
       </div>
     );
   }
 
   if (!product) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">Product Not Found</h1>
-          <Link href="/" className="text-blue-600 hover:text-blue-700">
-            Return to Home
-          </Link>
-        </div>
+      <div className="min-h-screen bg-white flex flex-col">
+        <Header />
+        <main className="flex-1 pt-20 sm:pt-24 flex items-center justify-center">
+          <div className="text-center">
+            <h1 className="text-4xl font-bold text-gray-900 mb-4">Product Not Found</h1>
+            <Link href="/" className="text-blue-600 hover:text-blue-700">
+              Return to Home
+            </Link>
+          </div>
+        </main>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-white">
-      {/* Hero Section */}
-      <section ref={heroRef} className="relative py-16 sm:py-20 lg:py-24 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
-            <div className={`transition-all duration-1000 ${heroInView ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
-              <span className="inline-block bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium mb-4">
-                {product.category}
-              </span>
+    <div className="min-h-screen bg-white flex flex-col">
+      <Header />
+      <main className="flex-1 pt-20 sm:pt-24">
+        {/* Hero Section */}
+        <section ref={heroRef} className="relative py-16 sm:py-20 lg:py-24 bg-gray-50">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-center">
+              <div className={`transition-all duration-1000 ${heroInView ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-8'}`}>
+                <span className="inline-block bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium mb-4">
+                  {product.category}
+                </span>
 
-              <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 mb-6">
-                {product.title}
-              </h1>
+                <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 mb-6">
+                  {product.title}
+                </h1>
 
-              <p className="text-lg text-gray-600 mb-8 leading-relaxed">
-                {product.fullDescription}
-              </p>
-
-              <div className="flex flex-col sm:flex-row gap-4">
-                <button className="bg-blue-600 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-700 transition-colors whitespace-nowrap cursor-pointer">
-                  <i className="ri-phone-line mr-2 w-4 h-4 flex items-center justify-center inline-flex"></i>
-                  Contact Sales
-                </button>
-                <button className="border border-gray-300 text-gray-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-50 transition-colors whitespace-nowrap cursor-pointer">
-                  <i className="ri-download-line mr-2 w-4 h-4 flex items-center justify-center inline-flex"></i>
-                  Download Specs
-                </button>
-              </div>
-            </div>
-
-            <div className={`transition-all duration-1000 ${heroInView ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'}`}>
-              <div className="relative overflow-hidden rounded-2xl shadow-2xl" data-product-shop>
-                <img
-                  src={product.image}
-                  alt={product.title}
-                  className="w-full h-96 object-cover object-top hover:scale-105 transition-transform duration-700"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Image Gallery */}
-      <section className="py-12 sm:py-16 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {product.dealGallery.map((image, index) => (
-              <div key={index} className="relative overflow-hidden rounded-xl shadow-lg group">
-                <img
-                  src={image}
-                  alt={`${product.title} view ${index + 1}`}
-                  className="w-full h-64 object-cover object-top group-hover:scale-105 transition-transform duration-500"
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Specifications */}
-      <section ref={specsRef} className="py-16 sm:py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className={`text-center mb-12 transition-all duration-1000 ${specsInView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
-            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
-              Technical Specifications
-            </h2>
-            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              Detailed technical specifications and performance parameters
-            </p>
-          </div>
-
-          <div className="grid gap-8 md:grid-cols-2">
-            <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
-              <h3 className="text-2xl font-semibold text-gray-900 mb-6">Key Specifications</h3>
-              <dl className="space-y-4">
-                {Object.entries(product.specifications).map(([key, value]) => (
-                  <div key={key} className="flex flex-col sm:flex-row sm:items-center">
-                    <dt className="text-sm font-medium text-gray-500 sm:w-1/3">
-                      {key}
-                    </dt>
-                    <dd className="mt-1 text-base text-gray-900 sm:mt-0 sm:w-2/3">
-                      {value}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-
-            <div className="space-y-8">
-              <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
-                <h3 className="text-2xl font-semibold text-gray-900 mb-6">Key Features</h3>
-                <ul className="space-y-4">
-                  {product.dealFeatures.map((feature, index) => (
-                    <li key={index} className="flex items-start">
-                      <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 font-semibold mr-4">
-                        {index + 1}
-                      </span>
-                      <span className="text-base text-gray-700 leading-relaxed">
-                        {feature}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
-                <h3 className="text-2xl font-semibold text-gray-900 mb-6">Application Scenarios</h3>
-                <ul className="space-y-3">
-                  {product.dealApplications.map((application, index) => (
-                    <li key={index} className="flex items-start text-base text-gray-700">
-                      <i className="ri-checkbox-circle-line text-blue-600 mr-3 mt-1"></i>
-                      <span>{application}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section ref={featuresRef} className="py-16 sm:py-20 lg:py-24 bg-white">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className={`bg-gradient-to-r from-blue-600 to-blue-700 rounded-3xl px-8 py-12 sm:px-12 sm:py-16 lg:px-16 lg:py-20 shadow-2xl text-white transition-all duration-1000 ${featuresInView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
-            <div className="grid lg:grid-cols-5 gap-10 lg:gap-16 items-center">
-              <div className="lg:col-span-3">
-                <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6">
-                  Ready to deploy a world-class energy storage solution?
-                </h2>
-                <p className="text-lg text-blue-100 mb-8 leading-relaxed">
-                  Our experts will help you design and implement the perfect system for your requirements, from consultation to deployment.
+                <p className="text-lg text-gray-600 mb-8 leading-relaxed">
+                  {product.fullDescription}
                 </p>
+
                 <div className="flex flex-col sm:flex-row gap-4">
-                  <button className="bg-white text-blue-700 px-8 py-3 rounded-full font-semibold hover:bg-blue-50 transition-colors whitespace-nowrap cursor-pointer">
-                    Schedule a Consultation
+                  <button className="bg-blue-600 text-white px-8 py-3 rounded-full font-semibold hover:bg-blue-700 transition-colors whitespace-nowrap cursor-pointer">
+                    <i className="ri-phone-line mr-2 w-4 h-4 flex items-center justify-center inline-flex"></i>
+                    Contact Sales
                   </button>
-                  <button className="border border-white text-white px-8 py-3 rounded-full font-semibold hover:bg-white/10 transition-colors whitespace-nowrap cursor-pointer">
-                    Download Full Brochure
+                  <button className="border border-gray-300 text-gray-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-50 transition-colors whitespace-nowrap cursor-pointer">
+                    <i className="ri-download-line mr-2 w-4 h-4 flex items-center justify-center inline-flex"></i>
+                    Download Specs
                   </button>
                 </div>
               </div>
 
-              <div className="lg:col-span-2">
-                <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-6 sm:p-8 border border-white/20 shadow-xl">
-                  <div className="flex items-center gap-4 mb-6">
-                    <div className="w-12 h-12 rounded-full bg-white/20 flex items-center justify-center">
-                      <i className="ri-flashlight-line text-2xl"></i>
-                    </div>
-                    <div>
-                      <h3 className="text-xl font-semibold">Why choose us?</h3>
-                      <p className="text-blue-100 text-sm">Trusted by industry leaders worldwide</p>
-                    </div>
-                  </div>
+              <div className={`transition-all duration-1000 ${heroInView ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-8'}`}>
+                <div className="relative overflow-hidden rounded-2xl shadow-2xl" data-product-shop>
+                  <img
+                    src={product.image}
+                    alt={product.title}
+                    className="w-full h-96 object-cover object-top hover:scale-105 transition-transform duration-700"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
 
-                  <ul className="space-y-4 text-blue-50 text-sm">
-                    <li className="flex items-center gap-3">
-                      <i className="ri-checkbox-circle-line text-xl"></i>
-                      <span>End-to-end energy storage solutions</span>
-                    </li>
-                    <li className="flex items-center gap-3">
-                      <i className="ri-checkbox-circle-line text-xl"></i>
-                      <span>24/7 monitoring and support services</span>
-                    </li>
-                    <li className="flex items-center gap-3">
-                      <i className="ri-checkbox-circle-line text-xl"></i>
-                      <span>Proven track record across industries</span>
-                    </li>
-                    <li className="flex items-center gap-3">
-                      <i className="ri-checkbox-circle-line text-xl"></i>
-                      <span>Scalable systems tailored to your needs</span>
-                    </li>
+        {/* Image Gallery */}
+        <section className="py-12 sm:py-16 bg-white">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {product.dealGallery.map((image, index) => (
+                <div key={index} className="relative overflow-hidden rounded-xl shadow-lg group">
+                  <img
+                    src={image}
+                    alt={`${product.title} view ${index + 1}`}
+                    className="w-full h-64 object-cover object-top group-hover:scale-105 transition-transform duration-500"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Specifications */}
+        <section ref={specsRef} className="py-16 sm:py-20 bg-gray-50">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className={`text-center mb-12 transition-all duration-1000 ${specsInView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
+              <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+                Technical Specifications
+              </h2>
+              <p className="text-lg text-gray-600 max-w-3xl mx-auto">
+                Detailed technical specifications and performance parameters
+              </p>
+            </div>
+
+            <div className="grid gap-8 md:grid-cols-2">
+              <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+                <h3 className="text-2xl font-semibold text-gray-900 mb-6">Key Specifications</h3>
+                <dl className="space-y-4">
+                  {Object.entries(product.specifications).map(([key, value]) => (
+                    <div key={key} className="flex flex-col sm:flex-row sm:items-center">
+                      <dt className="text-sm font-medium text-gray-500 sm:w-1/3">
+                        {key}
+                      </dt>
+                      <dd className="mt-1 text-base text-gray-900 sm:mt-0 sm:w-2/3">
+                        {value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+
+              <div className="space-y-8">
+                <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+                  <h3 className="text-2xl font-semibold text-gray-900 mb-6">Key Features</h3>
+                  <ul className="space-y-4">
+                    {product.dealFeatures.map((feature, index) => (
+                      <li key={index} className="flex items-start">
+                        <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 font-semibold mr-4">
+                          {index + 1}
+                        </span>
+                        <span className="text-base text-gray-700 leading-relaxed">
+                          {feature}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+                  <h3 className="text-2xl font-semibold text-gray-900 mb-6">Application Scenarios</h3>
+                  <ul className="space-y-3">
+                    {product.dealApplications.map((application, index) => (
+                      <li key={index} className="flex items-start text-base text-gray-700">
+                        <i className="ri-checkbox-circle-line text-blue-600 mr-3 mt-1"></i>
+                        <span>{application}</span>
+                      </li>
+                    ))}
                   </ul>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+
+        {/* CTA Section */}
+        <section ref={featuresRef} className="py-16 sm:py-20 lg:py-24 bg-white">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className={`bg-gradient-to-r from-blue-600 to-blue-700 rounded-3xl px-8 py-12 sm:px-12 sm:py-16 lg:px-16 lg:py-20 shadow-2xl text-white transition-all duration-1000 ${featuresInView ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}>
+              <div className="grid lg:grid-cols-5 gap-10 lg:gap-16 items-center">
+                <div className="lg:col-span-3">
+                  <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6">
+                    Ready to deploy a world-class energy storage solution?
+                  </h2>
+                  <p className="text-lg text-blue-100 mb-8 leading-relaxed">
+                    Our experts will help you design and implement the perfect system for your requirements, from consultation to deployment.
+                  </p>
+                  <div className="flex flex-col sm:flex-row gap-4">
+                    <button className="bg-white text-blue-700 px-8 py-3 rounded-full font-semibold hover:bg-blue-50 transition-colors whitespace-nowrap cursor-pointer">
+                      Schedule a Consultation
+                    </button>
+                    <button className="border border-white text-white px-8 py-3 rounded-full font-semibold hover:bg-white/10 transition-colors whitespace-nowrap cursor-pointer">
+                      Download Full Brochure
+                    </button>
+                  </div>
+                </div>
+
+                <div className="lg:col-span-2">
+                  <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-6 sm:p-8 border border-white/20 shadow-xl">
+                    <div className="flex items-center gap-4 mb-6">
+                      <div className="w-12 h-12 rounded-full bg-white/20 flex items-center justify-center">
+                        <i className="ri-flashlight-line text-2xl"></i>
+                      </div>
+                      <div>
+                        <h3 className="text-xl font-semibold">Why choose us?</h3>
+                        <p className="text-blue-100 text-sm">Trusted by industry leaders worldwide</p>
+                      </div>
+                    </div>
+
+                    <ul className="space-y-4 text-blue-50 text-sm">
+                      <li className="flex items-center gap-3">
+                        <i className="ri-checkbox-circle-line text-xl"></i>
+                        <span>End-to-end energy storage solutions</span>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <i className="ri-checkbox-circle-line text-xl"></i>
+                        <span>24/7 monitoring and support services</span>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <i className="ri-checkbox-circle-line text-xl"></i>
+                        <span>Proven track record across industries</span>
+                      </li>
+                      <li className="flex items-center gap-3">
+                        <i className="ri-checkbox-circle-line text-xl"></i>
+                        <span>Scalable systems tailored to your needs</span>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- include the shared Header component in the product detail experience so the top navigation appears on loading, error, and content states
- wrap product detail content in a main layout with top padding to keep sections clear of the fixed header

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbebdcaa0832489ffe9ffa1680960